### PR TITLE
Don't use instance metadata service

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -12,7 +12,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
       `cd "${config.input.runnerHomeDir}"`,
       'export RUNNER_ALLOW_RUNASROOT=1',
       'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-      'export INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)',
+      'export INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id)',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --name "$INSTANCE_ID" --labels ${label}`,
       './run.sh',
     ];
@@ -25,7 +25,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
       'tar xzf ./actions-runner-linux-${RUNNER_ARCH}-2.280.3.tar.gz',
       'export RUNNER_ALLOW_RUNASROOT=1',
       'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-      'export INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)',
+      'export INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id)',
       `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --name "$INSTANCE_ID" --labels ${label}`,
       './run.sh',
     ];


### PR DESCRIPTION
Updating IMDS to v2 which means you need to send a token with the
request, meaning this curl request gets more complicated.

Instead, just cat the file that has the Instance ID

- Update to IMDSv2: https://github.com/fac/infrastructure-modules/pull/1326


DevP ticket: https://github.com/fac/dev-platform/issues/553